### PR TITLE
Fix HF_HOME environment variable handling for model cache

### DIFF
--- a/mlx_knife/cache_utils.py
+++ b/mlx_knife/cache_utils.py
@@ -10,7 +10,10 @@ from pathlib import Path
 __version__ = "1.0-beta-1"
 
 DEFAULT_CACHE = Path.home() / ".cache/huggingface/hub"
-MODEL_CACHE = Path(os.environ.get("HF_HOME", DEFAULT_CACHE))
+if "HF_HOME" in os.environ:
+    MODEL_CACHE = Path(os.environ["HF_HOME"]) / "hub"
+else:
+    MODEL_CACHE = DEFAULT_CACHE
 
 
 def hf_to_cache_dir(hf_name: str) -> str:


### PR DESCRIPTION
When HF_HOME is set, models are stored in $HF_HOME/hub not directly in $HF_HOME. This fix ensures mlxk correctly locates models when using custom cache directories.

Closes #11 