### PR TITLE
Fix: Web API missing non-mlx-community models from /v1/models endpoint

### DIFF
--- a/mlxk2/core/server_base.py
+++ b/mlxk2/core/server_base.py
@@ -583,7 +583,7 @@ async def health_check():
 async def list_models():
     """List available MLX models in the cache."""
     from .cache import cache_dir_to_hf
-    from ..operations.common import detect_framework
+    from ..operations.common import detect_framework, read_front_matter
     from ..operations.health import is_model_healthy
     
     model_list = []
@@ -604,8 +604,12 @@ async def list_models():
                 snapshots = [d for d in snapshots_dir.iterdir() if d.is_dir()]
                 if snapshots:
                     selected_path = snapshots[0]
-            
-            if detect_framework(model_name, model_dir, selected_path) == "MLX" and is_model_healthy(model_name)[0]:
+
+            # Read front-matter for framework detection (align with CLI behavior)
+            probe = selected_path if selected_path is not None else model_dir
+            fm = read_front_matter(probe)
+
+            if detect_framework(model_name, model_dir, selected_path, fm) == "MLX" and is_model_healthy(model_name)[0]:
                 # Get model context length (best effort)
                 context_length = None
                 try:


### PR DESCRIPTION
## Summary

Fixes #41 - The web API endpoint `/v1/models` now correctly lists MLX models from all organizations, not just `mlx-community/*`.

## Problem

The `/v1/models` endpoint was not reading README front-matter before detecting model frameworks, causing it to only recognize models from `mlx-community/*`. Models from other organizations (like `lmstudio-community`) with proper MLX tags in their README were filtered out.

## Solution

This PR makes the web API use the same front-matter detection as the CLI:
- Import `read_front_matter` from `operations.common`
- Read README front-matter before calling `detect_framework()`
- Pass `fm` parameter to align with CLI behavior (completes #31)

## Testing

**Environment:**
- Python 3.13.9
- Apple M1 Pro
- mlx-knife 2.0.1 (with this fix)

**Manual verification:**
```bash
# Before fix: lmstudio-community model missing from API
curl http://localhost:8000/v1/models
# After fix: Both models appear correctly
{
  "object": "list",
  "data": [
    {"id": "lmstudio-community/Qwen3-4B-Thinking-2507-MLX-4bit", ...},
    {"id": "mlx-community/SmolLM3-3B-8bit", ...}
  ]
}
```

**Test suite results:**
- ✅ 293 tests passed
- ✅ All server endpoint tests passing
- ✅ Code quality checks passing (`ruff check mlxk2/ --fix`)
- 32 tests skipped (live tests requiring downloaded models)
- 1 pre-existing failure (APFS filesystem detection, unrelated to this change)

## Changes

**File:** `mlxk2/core/server_base.py`
- Line 586: Add `read_front_matter` to imports
- Lines 608-610: Read front-matter before framework detection
- Line 612: Pass `fm` parameter to `detect_framework()`

**Total:** 1 file changed, 7 insertions(+), 3 deletions(-)

---

Signed-off-by: Robert Clark <robert.clark@niftybean.com>